### PR TITLE
Expose port 3000 on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,6 @@ USER 1001:1001
 
 HEALTHCHECK CMD curl --fail http://localhost:3000/hello-world || exit 1
 
+EXPOSE 3000
+
 CMD ["node", "./index.js"]


### PR DESCRIPTION
Port 3000 needs to be exposed in order to serve the application after deployment